### PR TITLE
Type Conversion Hotfix

### DIFF
--- a/lib/dvf/parse.rs
+++ b/lib/dvf/parse.rs
@@ -425,6 +425,9 @@ impl DumpedDVF {
             .constructor_args
             .iter()
             .map(|x| -> DVFConstructorArg {
+                // TODO: This is wrong. Hotfixed for now
+                // Needs a proper translation, e.g. uint[] => t_array_uint...
+                // Then those types might be unknown
                 let translated_type = format!("t_{}", &x.type_string);
                 DVFConstructorArg {
                     var_name: x.name.clone(),

--- a/lib/state/contract_state.rs
+++ b/lib/state/contract_state.rs
@@ -653,7 +653,8 @@ impl<'a> ContractState<'a> {
     }
 
     pub fn is_address(var_type: &str) -> bool {
-        (var_type.starts_with("t_address") || var_type.starts_with("t_contract")) && !var_type.contains("[]")
+        (var_type.starts_with("t_address") || var_type.starts_with("t_contract"))
+            && !var_type.contains("[]")
     }
 
     pub fn is_int(var_type: &str) -> bool {
@@ -665,7 +666,9 @@ impl<'a> ContractState<'a> {
     }
 
     pub fn is_fixed_bytes(var_type: &str) -> bool {
-        var_type.starts_with("t_bytes") && var_type.chars().last().unwrap().is_ascii_digit() && !var_type.contains("[]")
+        var_type.starts_with("t_bytes")
+            && var_type.chars().last().unwrap().is_ascii_digit()
+            && !var_type.contains("[]")
     }
 
     pub fn is_basic_type(var_type: &str) -> bool {

--- a/lib/state/contract_state.rs
+++ b/lib/state/contract_state.rs
@@ -649,23 +649,23 @@ impl<'a> ContractState<'a> {
     }
 
     pub fn is_uint(var_type: &str) -> bool {
-        var_type.starts_with("t_uint")
+        var_type.starts_with("t_uint") && !var_type.contains("[]")
     }
 
     pub fn is_address(var_type: &str) -> bool {
-        var_type.starts_with("t_address") || var_type.starts_with("t_contract")
+        (var_type.starts_with("t_address") || var_type.starts_with("t_contract")) && !var_type.contains("[]")
     }
 
     pub fn is_int(var_type: &str) -> bool {
-        var_type.starts_with("t_int")
+        var_type.starts_with("t_int") && !var_type.contains("[]")
     }
 
     pub fn is_bool(var_type: &str) -> bool {
-        var_type.starts_with("t_bool")
+        var_type.starts_with("t_bool") && !var_type.contains("[]")
     }
 
     pub fn is_fixed_bytes(var_type: &str) -> bool {
-        var_type.starts_with("t_bytes") && var_type.chars().last().unwrap().is_ascii_digit()
+        var_type.starts_with("t_bytes") && var_type.chars().last().unwrap().is_ascii_digit() && !var_type.contains("[]")
     }
 
     pub fn is_basic_type(var_type: &str) -> bool {


### PR DESCRIPTION
Currently, we incorrectly convert between different variable typestrings. This is just a hotfix so that the pretty printing does not crash. 