### PR TITLE
Build cache for implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,12 @@ If the Hardhat project does not store its compilation artifacts in the default d
 dv init --project <PROJECT_PATH> --address <ADDRESS> --contractname <NAME> --implementation <IMPL_NAME> --implementationproject <IMPL_PROJECT_PATH> --implementationenv hardhat --implementationartifacts <IMPL_ARTIFACTS> new.dvf.json
 ```
 
+If you have to use an external build-info (i.e., you don't want `dv` to build the implementation project), you can specify the path to the implementation project's build-info directory with `--implementationbuildcache`:
+
+```
+dv init --project <PROJECT_PATH> --address <ADDRESS> --contractname <NAME> --implementation <IMPL_NAME> --implementationproject <IMPL_PROJECT_PATH> --implementationbuildcache <IMPL_BUILD_CACHE> new.dvf.json
+```
+
 Please note that this does not validate the implementation contract itself. If there are any security risks associated with the implementation contracts, you should create another DVF for it and then create a reference (see [References](#references)) from the original DVF to the implementation contract's DVF.
 
 ### Factories

--- a/src/dvf.rs
+++ b/src/dvf.rs
@@ -755,7 +755,7 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
             } else {
                 imp_path = path.clone();
                 imp_artifacts_path = artifacts_path.clone();
-                imp_build_cache = build_cache.clone();
+                imp_build_cache = build_cache;
                 imp_env = env
             }
 
@@ -810,7 +810,7 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
             debug!("Fetching forge output");
             let compile_output = match build_cache {
                 None => "Compiling local code.",
-                Some(_) => "Loading build cache."
+                Some(_) => "Loading build cache.",
             };
             print_progress(compile_output, &mut pc, &progress_mode);
             let mut project_info = ProjectInfo::new(


### PR DESCRIPTION
Added build-cache support for implementation contracts.
if an implementation project is set, the implementation build cache is used. otherwise, the regular build cache is used (if it is set).