### PR TITLE
Parse Blockscout response as array

### DIFF
--- a/lib/web3.rs
+++ b/lib/web3.rs
@@ -625,15 +625,16 @@ fn get_deployment_tx_from_blockscout(
 
     let result = send_blocking_blockscout_get(config, &url)?;
     debug!("Trying to parse Deployment response: {result:?}");
-    if let Ok(creation) = serde_json::from_value::<ContractCreation>(result.clone()){
+    if let Ok(creation) = serde_json::from_value::<ContractCreation>(result.clone()) {
         return Ok(creation.transaction_hash.clone());
-    }else if let Ok(creations) = serde_json::from_value::<Vec<ContractCreation>>(result){
+    } else if let Ok(creations) = serde_json::from_value::<Vec<ContractCreation>>(result) {
         return Ok(creations[0].transaction_hash.clone());
     }
 
     debug!("Failed to parse Deployment response.");
-    Err(ValidationError::Error("Failed to parse Deployment response".to_string()))
-
+    Err(ValidationError::Error(
+        "Failed to parse Deployment response".to_string(),
+    ))
 }
 
 pub fn get_deployment_block(config: &DVFConfig, address: &Address) -> Result<u64, ValidationError> {

--- a/lib/web3.rs
+++ b/lib/web3.rs
@@ -624,9 +624,16 @@ fn get_deployment_tx_from_blockscout(
     );
 
     let result = send_blocking_blockscout_get(config, &url)?;
-    let creation: ContractCreation = serde_json::from_value(result)?;
+    debug!("Trying to parse Deployment response: {result:?}");
+    if let Ok(creation) = serde_json::from_value::<ContractCreation>(result.clone()){
+        return Ok(creation.transaction_hash.clone());
+    }else if let Ok(creations) = serde_json::from_value::<Vec<ContractCreation>>(result){
+        return Ok(creations[0].transaction_hash.clone());
+    }
 
-    Ok(creation.transaction_hash.clone())
+    debug!("Failed to parse Deployment response.");
+    Err(ValidationError::Error("Failed to parse Deployment response".to_string()))
+
 }
 
 pub fn get_deployment_block(config: &DVFConfig, address: &Address) -> Result<u64, ValidationError> {


### PR DESCRIPTION
Apparently deployment transactions are now returned as an array:
https://docs.blockscout.com/devs/apis/rpc/contract#get-contract-creator-address-hash-and-creation-transaction-hash

For now support array and single response and just assume that we want the first array element.