### PR TITLE
Change installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ To install `dv`, clone this repository and build:
 ```
 git clone https://github.com/ChainSecurity/deployment_validation
 cd deployment-validation
-cargo build --release
-mv dv .
+cargo install --path . --locked
 ```
 
 This creates a binary at `~/.cargo/bin`. You can add the location to your `PATH` with the following command:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ To install `dv`, clone this repository and build:
 ```
 git clone https://github.com/ChainSecurity/deployment_validation
 cd deployment-validation
-cargo install --path .
+cargo build --release
+mv dv .
 ```
 
 This creates a binary at `~/.cargo/bin`. You can add the location to your `PATH` with the following command:


### PR DESCRIPTION
Change the installation instructions in the README

For some obscure reason, `cargo build` works, while `cargo install` throws an error on the same codebase.