### PR TITLE
Support Empty Array in Constructor Arguments

### DIFF
--- a/lib/bytecode_verification/compare_bytecodes.rs
+++ b/lib/bytecode_verification/compare_bytecodes.rs
@@ -54,7 +54,11 @@ fn ignore_subcontracts_metadata(
                 continue;
             }
             let length = other_bytecode.len() - metadata_index - 2;
-            // println!("{:?}, {:?}", subcontract_index + start_index + metadata_index, length);
+            debug!(
+                "Replacing subcontract from {:?}, length {:?}",
+                subcontract_index + start_index + metadata_index,
+                length
+            );
             for rel_index in relevant_indices
                 .iter_mut()
                 .skip(subcontract_index + start_index + metadata_index)
@@ -291,16 +295,21 @@ impl CompareInitCode {
             .abi_decode_input(&init_bytecode[compiled_init_code.len()..])
             .expect("Unable to decode the constructor arguments.");
 
-        for (arg, value) in project_info.constructor_args.iter_mut().zip(decoded_args) {
+        for (arg, value) in project_info.constructor_args.iter_mut().zip(&decoded_args) {
             let encoded_value = value.abi_encode_packed();
-            let formatted_value = format!("0x{}", hex::encode(&encoded_value));
+            if encoded_value.len() == 0 {
+                // Here we keep the arg.type_string we previous extracted from the ABI
+                // This happens with empty arrays
+                arg.value = "0x".to_string();
+            } else {
+                let formatted_value = format!("0x{}", hex::encode(&encoded_value));
+                let sol_type = value.as_type().unwrap_or_else(|| {
+                    panic!("Unable to find constructor argument type for {}", arg.name)
+                });
 
-            let sol_type = value.as_type().unwrap_or_else(|| {
-                panic!("Unable to find constructor argument type for {}", arg.name)
-            });
-
-            arg.value = formatted_value;
-            arg.type_string = sol_type.sol_type_name().to_string()
+                arg.value = formatted_value;
+                arg.type_string = sol_type.sol_type_name().to_string()
+            }
         }
 
         // Byte offset -> Relevant

--- a/lib/bytecode_verification/parse_json.rs
+++ b/lib/bytecode_verification/parse_json.rs
@@ -1443,7 +1443,9 @@ impl ProjectInfo {
 
         // TODO: Understand this better
         if build_infos.is_empty() {
-            return Err(ValidationError::from("No build-info files could be found."));
+            return Err(ValidationError::from(format!(
+                "No build-info files for {contract_name} could be found."
+            )));
         } else if build_infos.len() != 1 {
             return Err(ValidationError::from(format!(
                 "Multiple build-info files found. Try running {} in the project folder.",
@@ -1529,7 +1531,8 @@ impl ProjectInfo {
                     .iter()
                     .map(|input| ConstructorArg {
                         name: input.name.clone(),
-                        type_string: String::new(),
+                        type_string: input.selector_type().to_string(), // Only used as backup for now,
+                        // TODO: Check with parsed value
                         value: String::new(),
                     })
                     .collect();


### PR DESCRIPTION
Currently the code fails when there is an empty array passed as a constructor argument because it cannot figure out the type during the decoding.

Now we remember the type given by the ABI.

Long-term we should probably generally check that ABI types and decoded types match.