### PR TITLE
Consistently treat code errors

### DIFF
--- a/lib/bytecode_verification/verify_bytecode.rs
+++ b/lib/bytecode_verification/verify_bytecode.rs
@@ -79,15 +79,41 @@ pub fn write_out_bytecodes(
     let mut on_chain_file = File::create("on_chain_bytecode.txt").expect("Could not create file");
 
     compiled_file
-        .write_all(project_info.compiled_bytecode.as_bytes())
+        .write_all(
+            project_info
+                .compiled_bytecode
+                .trim_start_matches("0x")
+                .as_bytes(),
+        )
         .unwrap();
     on_chain_file
-        .write_all(on_chain_bytecode.as_bytes())
+        .write_all(on_chain_bytecode.trim_start_matches("0x").as_bytes())
         .unwrap();
 
     table.add_row(row![
         "output files",
         format!("{}\n{}", "compiled_bytecode.txt", "on_chain_bytecode.txt")
+    ]);
+}
+
+pub fn write_out_initcodes(
+    project_info: &ProjectInfo,
+    on_chain_initcode: &String,
+    table: &mut Table,
+) {
+    let mut compiled_file = File::create("compiled_initcode.txt").expect("Could not create file");
+    let mut on_chain_file = File::create("on_chain_initcode.txt").expect("Could not create file");
+
+    compiled_file
+        .write_all(project_info.init_code.trim_start_matches("0x").as_bytes())
+        .unwrap();
+    on_chain_file
+        .write_all(on_chain_initcode.trim_start_matches("0x").as_bytes())
+        .unwrap();
+
+    table.add_row(row![
+        "output files",
+        format!("{}\n{}", "compiled_initcode.txt", "on_chain_initcode.txt")
     ]);
 }
 

--- a/src/dvf.rs
+++ b/src/dvf.rs
@@ -895,14 +895,24 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
                 }
             }
 
-            print_progress("Comparing init code.", &mut pc, &progress_mode);
+            print_progress("Comparing initcode.", &mut pc, &progress_mode);
             let compare_init =
                 CompareInitCode::compare(&mut project_info, &init_code, factory_mode);
             if !compare_init.matched {
-                return Err(ValidationError::Error(format!(
-                    "Init code not matched for contract {:?}",
-                    dumped.address
-                )));
+                if matches.get_count("verbose") > 0 {
+                    let mut error_info_table = Table::new();
+                    verify_bytecode::write_out_initcodes(
+                        &project_info,
+                        &init_code,
+                        &mut error_info_table,
+                    );
+                    error_info_table.printstd();
+                } else {
+                    println!("Initcode mismatch. Run in verbose mode for more info.");
+                }
+                return Err(ValidationError::from(
+                    "Initcode mismatch. Consider running with --factory if this is a factory contract.",
+                ));
             }
             // immutable values are set in CompareBytecode::compare so this has to be after the call
             dumped.copy_immutables(&project_info, &pretty_printer);

--- a/tests/test_end_to_end.rs
+++ b/tests/test_end_to_end.rs
@@ -1451,7 +1451,10 @@ mod tests {
             println!("{}", &output);
 
             // The expected output should be Error occurred: Init code not matched for contract 0xa16e02e87b7454126e5e10d957a927a7f5b5d2be
-            assert!(output.contains("Error occurred: Initcode mismatch."), "The string does not contain the required text.");
+            assert!(
+                output.contains("Error occurred: Initcode mismatch."),
+                "The string does not contain the required text."
+            );
             drop(local_client);
         }
     }

--- a/tests/test_end_to_end.rs
+++ b/tests/test_end_to_end.rs
@@ -1451,7 +1451,7 @@ mod tests {
             println!("{}", &output);
 
             // The expected output should be Error occurred: Init code not matched for contract 0xa16e02e87b7454126e5e10d957a927a7f5b5d2be
-            assert!(output.contains("Error occurred: Init code not matched for contract 0xa16e02e87b7454126e5e10d957a927a7f5b5d2be"), "The string does not contain the required text.");
+            assert!(output.contains("Error occurred: Initcode mismatch."), "The string does not contain the required text.");
             drop(local_client);
         }
     }


### PR DESCRIPTION
Bytecode errors and initcode errors are now treated the same:

- Codes are outputed in verbose mode
- `--factory` recommendation is given for failures

Also the "0x" is removed if present.