### PR TITLE
Suppress logs from forge inspect

### DIFF
--- a/lib/state/forge_inspect.rs
+++ b/lib/state/forge_inspect.rs
@@ -174,6 +174,7 @@ impl ForgeInspect {
             contract = format!("{}:{}", path, contract_name);
         }
         let forge_inspect = Command::new("forge")
+            .env("RUST_LOG", "error") // prevents `forge inspect` from contaminating the JSON with logs
             .current_dir(project_path)
             .arg("inspect")
             .arg("--force")


### PR DESCRIPTION
### Steps to reproduce:

Have RUST_LOG="debug" in your environment.
Try to initialise a DVF.

### Result:
thread 'main' panicked at lib/state/forge_inspect.rs:203:55:
called `Result::unwrap()` on an `Err` value: Error("expected value", line: 1, column: 1)

### Reason:

When RUST_LOG="debug" the forge inspect outputs its logs in the stdout, together with the JSON string requested. The result is that the storage layout JSON string contains output logs and cannot be parsed into an object.

### Solution:

Run forge inspect with RUST_LOG="error". We expect forge inspect to only output the JSON result in the stdout or an error, not logs.