### PR TITLE
Cross-chain references

### DIFF
--- a/src/dvf.rs
+++ b/src/dvf.rs
@@ -88,8 +88,6 @@ fn validate_dvf(
 
     let filled = parse::CompleteDVF::from_path(input_file)?;
 
-    config.compare_chain_id(filled.chain_id)?;
-
     info!("Validating {}", input_file.display());
     filled.validate_id()?;
     if !allow_untrusted {


### PR DESCRIPTION
Currently, references to a DVF on another chain cannot be validated.

This would be, however, a useful feature. For example, a LayerZero bridge has a cross chain dependency as the endpoints on 2 different chains have to be set up in the same way.