### PR TITLE
Re-execute transactions locally

### DIFF
--- a/lib/bytecode_verification/compare_bytecodes.rs
+++ b/lib/bytecode_verification/compare_bytecodes.rs
@@ -297,7 +297,7 @@ impl CompareInitCode {
 
         for (arg, value) in project_info.constructor_args.iter_mut().zip(&decoded_args) {
             let encoded_value = value.abi_encode_packed();
-            if encoded_value.len() == 0 {
+            if encoded_value.is_empty() {
                 // Here we keep the arg.type_string we previous extracted from the ABI
                 // This happens with empty arrays
                 arg.value = "0x".to_string();

--- a/lib/bytecode_verification/verify_bytecode.rs
+++ b/lib/bytecode_verification/verify_bytecode.rs
@@ -24,7 +24,7 @@ pub fn print_verification_summary(
     contract_address: &Address,
     status: CompareBytecode,
     project_info: &ProjectInfo,
-    on_chain_bytecode: &String,
+    on_chain_bytecode: &str,
 ) {
     let mut table = Table::new();
 
@@ -70,11 +70,7 @@ pub fn print_verification_summary(
     table.printstd();
 }
 
-pub fn write_out_bytecodes(
-    project_info: &ProjectInfo,
-    on_chain_bytecode: &String,
-    table: &mut Table,
-) {
+pub fn write_out_bytecodes(project_info: &ProjectInfo, on_chain_bytecode: &str, table: &mut Table) {
     let mut compiled_file = File::create("compiled_bytecode.txt").expect("Could not create file");
     let mut on_chain_file = File::create("on_chain_bytecode.txt").expect("Could not create file");
 
@@ -96,11 +92,7 @@ pub fn write_out_bytecodes(
     ]);
 }
 
-pub fn write_out_initcodes(
-    project_info: &ProjectInfo,
-    on_chain_initcode: &String,
-    table: &mut Table,
-) {
+pub fn write_out_initcodes(project_info: &ProjectInfo, on_chain_initcode: &str, table: &mut Table) {
     let mut compiled_file = File::create("compiled_initcode.txt").expect("Could not create file");
     let mut on_chain_file = File::create("on_chain_initcode.txt").expect("Could not create file");
 
@@ -123,7 +115,7 @@ pub fn print_generation_summary(
     contract_address: &Address,
     status: CompareBytecode,
     project_info: &ProjectInfo,
-    on_chain_bytecode: &String,
+    on_chain_bytecode: &str,
     pretty_printer: &PrettyPrinter,
 ) {
     let mut table = Table::new();

--- a/lib/web3.rs
+++ b/lib/web3.rs
@@ -20,6 +20,7 @@ use crate::dvf::parse::ValidationError;
 
 use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::rpc::types::{Block, EIP1186AccountProofResponse, Log, Transaction, TransactionReceipt};
+use alloy_node_bindings::{Anvil, AnvilInstance};
 use alloy_rpc_types_trace::geth::{CallFrame, DefaultFrame, DiffMode, StructLog};
 use alloy_rpc_types_trace::parity::{
     Action, LocalizedTransactionTrace, TraceOutput, TransactionTrace,
@@ -246,21 +247,12 @@ pub fn get_eth_debug_call_trace(
     Ok(trace)
 }
 
-pub fn get_eth_debug_trace(
+/// Helper function to get transaction receipt and create TraceWithAddress
+fn create_trace_with_address(
     config: &DVFConfig,
     tx_id: &str,
+    trace: DefaultFrame,
 ) -> Result<TraceWithAddress, ValidationError> {
-    debug!("Obtaining debug trace.");
-    let request_body = json!({
-        "jsonrpc": "2.0",
-        "method": "debug_traceTransaction",
-        "params": [tx_id, {"enableMemory": true, "enableStorage": true, "enableReturnData": false}],
-        "id": 1
-    });
-    let result = send_blocking_web3_post(config, &request_body)?;
-    // Parse the response as a JSON list
-    let trace: DefaultFrame = serde_json::from_value(result)?;
-
     let request_body = json!({
         "jsonrpc": "2.0",
         "method": "eth_getTransactionReceipt",
@@ -268,7 +260,6 @@ pub fn get_eth_debug_trace(
         "id": 1
     });
     let result = send_blocking_web3_post(config, &request_body)?;
-    // Parse the response as a JSON list
     let receipt: TransactionReceipt = serde_json::from_value(result)?;
 
     let tx_id = tx_id.to_string();
@@ -279,16 +270,120 @@ pub fn get_eth_debug_trace(
             tx_id,
         })
     } else if let Some(address) = receipt.contract_address {
-        return Ok(TraceWithAddress {
+        Ok(TraceWithAddress {
             trace,
             address,
             tx_id,
-        });
+        })
     } else {
-        return Err(ValidationError::from(format!(
+        println!(
+            "[DEBUG] create_trace_with_address: No address found in receipt: {:?}",
+            receipt
+        );
+        Err(ValidationError::from(format!(
             "Found no address for tx {}",
             tx_id
-        )));
+        )))
+    }
+}
+
+pub fn get_eth_debug_trace(
+    config: &DVFConfig,
+    tx_id: &str,
+) -> Result<TraceWithAddress, ValidationError> {
+    debug!("Obtaining debug trace.");
+
+    // Try the first call to send_blocking_web3_post
+    let request_body = json!({
+        "jsonrpc": "2.0",
+        "method": "debug_traceTransaction",
+        "params": [tx_id, {"enableMemory": true, "enableStorage": true, "enableReturnData": false}],
+        "id": 1
+    });
+
+    match send_blocking_web3_post(config, &request_body) {
+        Ok(result) => {
+            // Parse the response as a JSON list
+            let trace: DefaultFrame = serde_json::from_value(result)?;
+            create_trace_with_address(config, tx_id, trace)
+        }
+        Err(_) => {
+            // First call failed, try fallback with anvil
+            info!("Initial debug_traceTransaction failed, trying fallback with anvil");
+
+            // Get transaction details
+            let (block_num, tx_index, tx_result) = get_transaction_details(config, tx_id)?;
+
+            // Get the RPC URL for the current chain
+            let rpc_url = config.get_rpc_url()?;
+
+            // Get the previous transaction in the same block
+            let (fork_transaction_hash, fork_block_number) =
+                match get_previous_transaction_in_block(config, block_num, tx_index)? {
+                    Some(prev_tx_hash) => (Some(prev_tx_hash), None),
+                    None => (None, Some(block_num - 1)), // Fallback to previous block if tx is first in block
+                };
+
+            // Start anvil with fork
+            let anvil_instance = start_anvil(
+                &rpc_url,
+                fork_transaction_hash.as_deref(),
+                fork_block_number,
+            )?;
+
+            // Create a new config with the anvil endpoint
+            let mut anvil_config = DVFConfig::default();
+            anvil_config
+                .rpc_urls
+                .insert(config.active_chain_id.unwrap(), anvil_instance.endpoint());
+            anvil_config.active_chain_id = config.active_chain_id;
+            anvil_config.web3_timeout = config.web3_timeout;
+
+            // Extract transaction data from the JSON response (already fetched in get_transaction_details)
+            let from = tx_result["from"].as_str().unwrap();
+            let to = tx_result["to"].as_str().unwrap_or("null");
+            let value = tx_result["value"].as_str().unwrap();
+            let data = tx_result["input"].as_str().unwrap();
+            let gas = tx_result["gas"].as_str().unwrap();
+            let gas_price = tx_result["gasPrice"].as_str().unwrap();
+
+            // Use debug_traceCall with the transaction's calldata
+            let trace_call_body = json!({
+                "jsonrpc": "2.0",
+                "method": "debug_traceCall",
+                "params": [
+                    {
+                        "from": from,
+                        "to": to,
+                        "value": value,
+                        "data": data,
+                        "gas": gas,
+                        "gasPrice": gas_price
+                    },
+                    "latest",
+                    {"enableMemory": true, "enableStorage": true, "enableReturnData": false}
+                ],
+                "id": 1
+            });
+
+            let result = match send_blocking_web3_post(&anvil_config, &trace_call_body) {
+                Ok(result) => result,
+                Err(e) => {
+                    // Stop the anvil instance before returning the error
+                    stop_anvil_instance(anvil_instance);
+                    return Err(e);
+                }
+            };
+            let trace: DefaultFrame = serde_json::from_value(result)?;
+
+            // Create the trace with address (this makes another RPC call to anvil)
+            let result = create_trace_with_address(config, tx_id, trace);
+
+            // Stop the anvil instance after all operations are complete
+            stop_anvil_instance(anvil_instance);
+
+            result
+        }
     }
 }
 
@@ -1151,7 +1246,7 @@ pub fn get_eth_chain_id(config: &DVFConfig) -> Result<u64, ValidationError> {
     Ok(chain_id)
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Web3Event {
     pub topics: Vec<String>,
     pub data: String,
@@ -2272,26 +2367,153 @@ mod tests {
     // }
 }
 
-pub fn get_eth_transaction_block_number(
+/// Get transaction details including block number, transaction index, and full transaction data
+pub fn get_transaction_details(
     config: &DVFConfig,
     tx_hash: &str,
-) -> Result<u64, ValidationError> {
+) -> Result<(u64, u64, serde_json::Value), ValidationError> {
     let request_body = json!({
         "jsonrpc": "2.0",
-        "method": "eth_getTransactionReceipt",
+        "method": "eth_getTransactionByHash",
         "params": [tx_hash],
         "id": 1
     });
     let result = send_blocking_web3_post(config, &request_body)?;
 
-    // Extract the block number from the receipt
-    let block_number_hex = result
-        .get("blockNumber")
-        .and_then(|bn| bn.as_str())
-        .ok_or_else(|| ValidationError::from("Block number not found in transaction receipt"))?;
+    let tx: Transaction = serde_json::from_value(result.clone())?;
 
-    // Convert the hex block number to u64
-    let receipt = u64::from_str_radix(block_number_hex.trim_start_matches("0x"), 16)
-        .map_err(|_| ValidationError::from("Failed to parse block number from hex"))?;
-    Ok(receipt)
+    match (tx.block_number, tx.transaction_index) {
+        (Some(block_num), Some(tx_index)) => Ok((block_num, tx_index, result)),
+        _ => Err(ValidationError::from("Transaction not found or not mined")),
+    }
+}
+
+/// Get the previous transaction hash in the same block
+fn get_previous_transaction_in_block(
+    config: &DVFConfig,
+    block_num: u64,
+    current_tx_index: u64,
+) -> Result<Option<String>, ValidationError> {
+    if current_tx_index == 0 {
+        // This is the first transaction in the block
+        return Ok(None);
+    }
+
+    let block = get_eth_block_by_num(config, block_num, true)?;
+
+    if let Some(transactions) = block.transactions.as_transactions() {
+        if current_tx_index > 0 && current_tx_index <= transactions.len() as u64 {
+            let prev_tx = &transactions[(current_tx_index - 1) as usize];
+            // Get the transaction hash directly from the transaction data
+            let hash = format!("{:#x}", prev_tx.inner.hash());
+            return Ok(Some(hash));
+        }
+    }
+
+    Err(ValidationError::from(
+        "Could not find previous transaction in block",
+    ))
+}
+
+/// Start anvil with fork using Anvil::new() with retry logic
+fn start_anvil(
+    fork_url: &str,
+    fork_transaction_hash: Option<&str>,
+    fork_block_number: Option<u64>,
+) -> Result<AnvilInstance, ValidationError> {
+    let mut anvil: Option<AnvilInstance> = None;
+
+    debug!("Starting Anvil with fork URL: {}", fork_url);
+
+    // Try to start anvil with retry logic, similar to start_local_client
+    for attempt in 0..10 {
+        let result = std::panic::catch_unwind(|| {
+            let mut anvil_builder = Anvil::new().fork(fork_url);
+
+            // Set either fork transaction hash or fork block number
+            if let Some(tx_hash) = fork_transaction_hash {
+                anvil_builder = anvil_builder.arg("--fork-transaction-hash").arg(tx_hash);
+            } else if let Some(block_num) = fork_block_number {
+                anvil_builder = anvil_builder
+                    .arg("--fork-block-number")
+                    .arg(block_num.to_string());
+            }
+
+            anvil_builder.spawn()
+        });
+
+        match result {
+            Ok(instance) => {
+                debug!("Anvil spawned successfully on attempt {}", attempt + 1);
+                anvil = Some(instance);
+                break;
+            }
+            Err(e) => {
+                debug!(
+                    "Anvil startup attempt {} failed: {:?}, retrying...",
+                    attempt + 1,
+                    e
+                );
+                // Wait for the other process to go away
+                std::thread::sleep(std::time::Duration::from_millis(250));
+            }
+        }
+    }
+
+    let anvil_instance =
+        anvil.ok_or_else(|| ValidationError::from("Failed to start anvil after 10 attempts"))?;
+
+    let endpoint = anvil_instance.endpoint();
+    debug!("Anvil endpoint: {}", endpoint);
+
+    // Wait for anvil to be ready by testing the connection
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+
+    for attempt in 0..10 {
+        let test_request = json!({
+            "jsonrpc": "2.0",
+            "method": "eth_chainId",
+            "params": [],
+            "id": 1
+        });
+
+        debug!(
+            "Testing Anvil connection attempt {} to {}",
+            attempt + 1,
+            endpoint
+        );
+        match client.post(&endpoint).json(&test_request).send() {
+            Ok(response) => {
+                if response.status().is_success() {
+                    debug!("Anvil is ready after {} attempts", attempt + 1);
+                    return Ok(anvil_instance);
+                } else {
+                    debug!("Anvil responded with status: {}", response.status());
+                }
+            }
+            Err(e) => {
+                debug!(
+                    "Anvil connection attempt {} failed: {}, retrying...",
+                    attempt + 1,
+                    e
+                );
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    Err(ValidationError::from(
+        "Anvil failed to become ready after 10 connection attempts",
+    ))
+}
+
+/// Stop an Anvil instance
+fn stop_anvil_instance(anvil_instance: AnvilInstance) {
+    // AnvilInstance implements Drop, so it will be automatically cleaned up
+    // when it goes out of scope, but we can also explicitly drop it
+    drop(anvil_instance);
 }

--- a/src/dvf.rs
+++ b/src/dvf.rs
@@ -164,7 +164,7 @@ fn validate_dvf(
         return Err(ValidationError::from("Different codehash."));
     }
 
-    let pretty_printer = PrettyPrinter::new(&config, Some(&registry));
+    let pretty_printer = PrettyPrinter::new(config, Some(registry));
 
     // Validate Storage slots
     print_progress("Validating Storage Variables.", &mut pc, &progress_mode);
@@ -181,7 +181,7 @@ fn validate_dvf(
         if !storage_variable.compare(&current_val[start_index..end_index]) {
             let message = get_mismatch_msg(
                 &pretty_printer,
-                &storage_variable,
+                storage_variable,
                 &current_val[start_index..end_index],
             );
             if continue_on_mismatch {
@@ -824,8 +824,8 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
 
             // Parse optional initblock or take deployment_block_num + 1
             let (deployment_block_num, deployment_tx) = if user_deployment_tx.is_some() {
-                let block_num =
-                    web3::get_eth_transaction_block_number(&config, user_deployment_tx.unwrap())?;
+                let (block_num, _, _) =
+                    web3::get_transaction_details(&config, user_deployment_tx.unwrap())?;
                 (block_num, user_deployment_tx.unwrap().clone())
             } else {
                 web3::get_deployment(&config, &dumped.address)?

--- a/tests/ci_tests.sh
+++ b/tests/ci_tests.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 set -ex
 
+compare_files() {
+    local file1="$1"
+    local file2="$2"
+    
+    echo "Comparing files..."
+    echo "File 1: $file1"
+    echo "File 2: $file2"
+    
+    if diff "$file1" "$file2" > /dev/null; then
+        echo "Files are identical"
+    else
+        echo "Files are different:"
+        diff "$file1" "$file2"
+        exit 1
+    fi
+}
+
 # Can use env with "set -a && source .env && set +a" for testing
 #export RUSTFLAGS='-D warnings'   # This flag makes pipeline fail on warnings
 pkill geth || true
@@ -27,8 +44,12 @@ cd tests/hardhat && yarn install -y && npx hardhat compile && cd -
 cd tests/hardhat_2_0 && yarn install -y && npx hardhat compile && cd -
 RUST_BACKTRACE=1 cargo test 
 envsubst < tests/config.json > /tmp/eval_config.json
+envsubst < tests/config_localsim.json > /tmp/eval_localsim_config.json
 cargo run --bin fetch-from-etherscan -- -c  /tmp/eval_config.json --address 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f --project /tmp/uni-factory
-cargo run --bin dv --  --config  /tmp/eval_config.json init --address 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f --project /tmp/uni-factory --chainid 1 --factory --zerovalue --contractname UniswapV2Factory UniswapV2Factory_0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f.dvf.json
+cargo run --bin dv --  --config  /tmp/eval_config.json init --address 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f --project /tmp/uni-factory --chainid 1 --factory --zerovalue --contractname UniswapV2Factory --initblock 10008355 UniswapV2Factory_0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f.dvf.json
+cargo run --bin dv --  --config  /tmp/eval_localsim_config.json init --address 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f --project /tmp/uni-factory --chainid 1 --factory --zerovalue --contractname UniswapV2Factory --initblock 10008355 UniswapV2Factory_0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f_localsim.dvf.json
+compare_files "UniswapV2Factory_0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f.dvf.json" "UniswapV2Factory_0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f_localsim.dvf.json"
+
 # TODO: Parse output
 cargo run --bin dv -- -c  /tmp/eval_config.json generate-build-cache --project /tmp/uni-factory
 cargo run --bin dv -- --verbose --verbose --config  /tmp/eval_config.json init --address 0x5e8422345238f34275888049021821e8e08caa1f --zerovalue --contractname frxETH --project examples/frxETH-public --initblock 15728402 examples/dvfs/frx_out.dvf.json

--- a/tests/config_localsim.json
+++ b/tests/config_localsim.json
@@ -1,0 +1,25 @@
+{
+    "rpc_urls": {
+        "1": "$MAINNET_RPC_WO_OPCODE_LOGS",
+        "1337": "http://127.0.0.1:8546",
+        "31337": "http://127.0.0.1:8546"
+    },
+    "etherscan_global": {
+        "api_url": "http://127.0.0.1:5002",
+        "api_key": "$ETHERSCAN_API_KEY"
+    },
+    "blockscout_global": {
+        "api_url": "http://127.0.0.1:5001",
+        "api_key": "$BLOCKSCOUT_API_KEY"
+    },
+    "dvf_storage": "/tmp/dvfs/",
+    "trusted_signers": [
+        "$SIGNER_ADDRESS"
+    ],
+    "signer": {
+        "wallet_type": {
+            "secret_key": "$SIGNER_SECRET_KEY"
+        },
+        "wallet_address": "$SIGNER_ADDRESS"
+    }
+}


### PR DESCRIPTION
If opcode logs cannot be retrieved from an RPC endpoint, try to start a local anvil forked from the last transaction before the current one and re-execute the transaction locally to retrieve the log.