### PR TITLE
Fix incorrect default configuration path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ docker run --rm -v $PWD:/home/dv/shared -it ghcr.io/chainsecurity/deployment_val
 
 ## Configuration
 
-Before `dv` can be used for validation and/or DVF creation, a configuration file has to be created. `dv` searches for the file in `~/.dvf_config.json` by default.
+Before `dv` can be used for validation and/or DVF creation, a configuration file has to be created. `dv` searches for the file in `~/.dv_config.json` by default.
 If you want to store the file at a different location, the `--config` parameter has to be used any time you run `dv`:
 
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,7 @@
 # Configuration File
 
 The configuration file is a JSON file that stores information used to generate dvf files; this includes parameters like RPC URLs, API keys, and trusted signers.
-When running the `dvf` command, the default configuration file is expected at `$HOME/.dvf_config.json`. Otherwise, its path can be specified using the `-c` option.
+When running the `dvf` command, the default configuration file is expected at `$HOME/.dv_config.json`. Otherwise, its path can be specified using the `-c` option.
 
 | Field | Description |
 | --- | --- |


### PR DESCRIPTION
The default configuration path is `~/.dv_config.json` and not `~/.dvf_config.json`.

Fixed the docs to reflect this.