### PR TITLE
Inspect transaction

### DIFF
--- a/lib/bytecode_verification/parse_json.rs
+++ b/lib/bytecode_verification/parse_json.rs
@@ -7,6 +7,7 @@ use alloy::json_abi::Constructor;
 use alloy::primitives::U256;
 use clap::ValueEnum;
 use semver::Version;
+use serde::{Deserialize, Serialize};
 use serde_json;
 use serde_json::Value;
 use std::path::Path;
@@ -1713,7 +1714,7 @@ impl ProjectInfo {
     }
 }
 
-#[derive(ValueEnum, Copy, Clone, Eq, PartialEq)]
+#[derive(ValueEnum, Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Environment {
     Foundry,
     Hardhat,

--- a/lib/dvf/config.rs
+++ b/lib/dvf/config.rs
@@ -30,6 +30,7 @@ use colored::Colorize;
 use dotenv::dotenv;
 use scanf::sscanf;
 use std::env;
+use crate::bytecode_verification::parse_json::Environment;
 
 pub const DEFAULT_CONFIG_LOCATION: &str = "~/.dv_config.json";
 const DEFAULT_FALLBACK_CONFIG_LOCATION: &str = "dv_config.json";
@@ -118,10 +119,46 @@ pub struct DVFConfig {
     #[serde(default = "default_web3_timeout")]
     pub web3_timeout: u64,
     pub signer: Option<DVFSignerConfig>,
+    /// Project configurations by project name
+    #[serde(default)]
+    pub projects: BTreeMap<String, DVFProjectConfig>,
     #[serde(skip_serializing)]
     pub active_chain_id: Option<u64>,
     #[serde(default, skip_serializing)]
     active_chain: Option<NamedChain>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DVFProjectConfig {
+    /// Path to the root folder of the source code project (required)
+    pub project_path: PathBuf,
+    /// Project's development environment
+    #[serde(default = "default_environment")]
+    pub environment: Environment,
+    /// Folder containing the project artifacts
+    #[serde(default = "default_artifacts_path")]
+    pub artifacts_path: String,
+    /// Folder containing build-info files
+    pub build_cache_path: Option<String>,
+    /// Library specifiers in the form Path:Name:Address
+    #[serde(default)]
+    pub libraries: Vec<String>,
+    /// Optional implementation project configuration for proxy contracts
+    pub implementation_config: Option<Box<DVFImplementationConfig>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DVFImplementationConfig {
+    /// Path to the root folder of the implementation project
+    pub project_path: PathBuf,
+    /// Implementation project's development environment
+    #[serde(default = "default_environment")]
+    pub environment: Environment,
+    /// Folder containing the implementation project artifacts
+    #[serde(default = "default_artifacts_path")]
+    pub artifacts_path: String,
+    /// Folder containing the implementation contract's build-info files
+    pub build_cache_path: Option<String>,
 }
 
 fn default_max_blocks() -> u64 {
@@ -130,6 +167,14 @@ fn default_max_blocks() -> u64 {
 
 fn default_web3_timeout() -> u64 {
     700
+}
+
+fn default_environment() -> Environment {
+    Environment::Foundry
+}
+
+fn default_artifacts_path() -> String {
+    "artifacts".to_string()
 }
 
 impl DVFConfig {
@@ -207,6 +252,7 @@ impl DVFConfig {
                     secret_key: env::var("SIGNER_SECRET_KEY")?,
                 }),
             }),
+            projects: BTreeMap::new(),
             active_chain_id: None,
             active_chain: None,
         })
@@ -921,6 +967,201 @@ impl DVFConfig {
                 println!("{}", "The provided address could not be parsed.".yellow());
             }
         }
+        /*
+        // Project configurations
+        let mut projects: BTreeMap<String, DVFProjectConfig> = BTreeMap::new();
+        println!();
+        println!("{}", "STEP 8".green());
+        println!("You can now configure projects for your DVF development.");
+        println!("Projects allow you to pre-configure development environments, artifact paths,");
+        println!("and other settings used by the 'init' command for specific contracts.");
+        println!();
+
+        loop {
+            println!(
+                "Would you like to add a project configuration? Hit {} to continue without adding projects.",
+                "<Enter>".green()
+            );
+            print!("> ");
+
+            let mut input = String::new();
+            let _ = std::io::Write::flush(&mut std::io::stdout());
+            io::stdin().read_line(&mut input).unwrap();
+
+            if input.trim().is_empty() {
+                break;
+            }
+
+            if input.trim().eq_ignore_ascii_case("y") {
+                // Project name
+                let mut project_name = String::new();
+                loop {
+                    println!("Please enter a name for this project:");
+                    print!("> ");
+
+                    let mut input = String::new();
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                    io::stdin().read_line(&mut input).unwrap();
+
+                    if sscanf!(&input, "{}", project_name).is_ok() && !project_name.is_empty() {
+                        break;
+                    } else {
+                        println!("{}", "Project name cannot be empty.".yellow());
+                    }
+                }
+
+                // Project path
+                let mut project_path = PathBuf::new();
+                loop {
+                    println!("Please enter the path to the root folder of the source code project:");
+                    print!("> ");
+
+                    let mut input = String::new();
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                    io::stdin().read_line(&mut input).unwrap();
+
+                    let mut path_str = String::new();
+                    if sscanf!(&input, "{}", path_str).is_ok() {
+                        if let Ok(path) = replace_tilde(path_str.trim()) {
+                            if path.exists() {
+                                project_path = path;
+                                break;
+                            } else {
+                                println!("{}", "The provided path does not exist.".yellow());
+                            }
+                        } else {
+                            println!("{}", "The provided path could not be parsed.".yellow());
+                        }
+                    } else {
+                        println!("{}", "The provided path could not be parsed.".yellow());
+                    }
+                }
+
+                // Development environment
+                let mut environment = Environment::Foundry;
+                loop {
+                    println!("Please select the development environment:");
+                    println!("1. Foundry");
+                    println!("2. Hardhat");
+                    println!("Hit {} to use default (Foundry)", "<Enter>".green());
+                    print!("> ");
+
+                    let mut input = String::new();
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                    io::stdin().read_line(&mut input).unwrap();
+
+                    if input.trim().is_empty() {
+                        break;
+                    }
+
+                    let mut choice: u64 = 0;
+                    if sscanf!(&input, "{}", choice).is_ok() {
+                        environment = match choice {
+                            1 => Environment::Foundry,
+                            2 => Environment::Hardhat,
+                            _ => {
+                                println!("{}", "Please enter a valid choice.".yellow());
+                                continue;
+                            }
+                        };
+                        break;
+                    } else {
+                        println!("{}", "The provided number could not be parsed.".yellow());
+                    }
+                }
+
+                // Artifacts path
+                let mut artifacts_path = String::from("artifacts");
+                loop {
+                    println!("Please enter the folder containing the project artifacts:");
+                    println!(
+                        "Hit {} to use default value: {}",
+                        "<Enter>".green(),
+                        artifacts_path.green()
+                    );
+                    print!("> ");
+
+                    let mut input = String::new();
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                    io::stdin().read_line(&mut input).unwrap();
+
+                    if input.trim().is_empty() {
+                        break;
+                    }
+
+                    let mut path_str = String::new();
+                    if sscanf!(&input, "{}", path_str).is_ok() && !path_str.is_empty() {
+                        artifacts_path = path_str;
+                        break;
+                    } else {
+                        println!("{}", "The provided path could not be parsed.".yellow());
+                    }
+                }
+
+                // Build cache path (optional)
+                let mut build_cache_path: Option<String> = None;
+                loop {
+                    println!("Please enter the folder containing build-info files:");
+                    println!("Hit {} to skip this configuration", "<Enter>".green());
+                    print!("> ");
+
+                    let mut input = String::new();
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                    io::stdin().read_line(&mut input).unwrap();
+
+                    if input.trim().is_empty() {
+                        break;
+                    }
+
+                    let mut path_str = String::new();
+                    if sscanf!(&input, "{}", path_str).is_ok() && !path_str.is_empty() {
+                        build_cache_path = Some(path_str);
+                        break;
+                    } else {
+                        println!("{}", "The provided path could not be parsed.".yellow());
+                    }
+                }
+
+                // Libraries (optional)
+                let mut libraries: Vec<String> = vec![];
+                loop {
+                    println!(
+                        "Please enter library specifiers in the form Path:Name:Address, or hit {} to finish:",
+                        "<Enter>".green()
+                    );
+                    print!("> ");
+
+                    let mut input = String::new();
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                    io::stdin().read_line(&mut input).unwrap();
+
+                    if input.trim().is_empty() {
+                        break;
+                    }
+
+                    let mut library = String::new();
+                    if sscanf!(&input, "{}", library).is_ok() && !library.is_empty() {
+                        libraries.push(library);
+                    } else {
+                        println!("{}", "The provided library specifier could not be parsed.".yellow());
+                    }
+                }
+
+                // Create project config
+                let project_config = DVFProjectConfig {
+                    project_path,
+                    environment,
+                    artifacts_path,
+                    build_cache_path,
+                    libraries,
+                    implementation_config: None, // For now, we'll add implementation config in a future update
+                };
+
+                projects.insert(project_name, project_config);
+                println!("{}", "Project configuration added successfully!".green());
+            }
+        }
+        */
 
         Ok(DVFConfig {
             rpc_urls,
@@ -933,6 +1174,8 @@ impl DVFConfig {
             max_blocks_per_event_query,
             web3_timeout,
             signer,
+            //projects,
+            projects: BTreeMap::new(),
             active_chain_id: None,
             active_chain: None,
         })
@@ -1180,6 +1423,26 @@ impl DVFConfig {
             "Could not find a suitable RPC URL for chainId {}",
             chain_id
         )))
+    }
+
+    /// Get a project configuration by name
+    pub fn get_project(&self, project_name: &str) -> Option<&DVFProjectConfig> {
+        self.projects.get(project_name)
+    }
+
+    /// Add or update a project configuration
+    pub fn set_project(&mut self, project_name: String, config: DVFProjectConfig) {
+        self.projects.insert(project_name, config);
+    }
+
+    /// Remove a project configuration
+    pub fn remove_project(&mut self, project_name: &str) -> Option<DVFProjectConfig> {
+        self.projects.remove(project_name)
+    }
+
+    /// List all project names
+    pub fn list_projects(&self) -> Vec<&String> {
+        self.projects.keys().collect()
     }
 }
 

--- a/lib/dvf/config.rs
+++ b/lib/dvf/config.rs
@@ -23,6 +23,7 @@ use serde_json::Value;
 use tempfile::{tempdir, NamedTempFile};
 use tracing::debug;
 
+use crate::bytecode_verification::parse_json::Environment;
 use crate::dvf::abstract_wallet::AbstractWallet;
 use crate::dvf::parse::ValidationError;
 use crate::web3;
@@ -30,7 +31,6 @@ use colored::Colorize;
 use dotenv::dotenv;
 use scanf::sscanf;
 use std::env;
-use crate::bytecode_verification::parse_json::Environment;
 
 pub const DEFAULT_CONFIG_LOCATION: &str = "~/.dv_config.json";
 const DEFAULT_FALLBACK_CONFIG_LOCATION: &str = "dv_config.json";
@@ -119,9 +119,8 @@ pub struct DVFConfig {
     #[serde(default = "default_web3_timeout")]
     pub web3_timeout: u64,
     pub signer: Option<DVFSignerConfig>,
-    /// Project configurations by project name
     #[serde(default)]
-    pub projects: BTreeMap<String, DVFProjectConfig>,
+    pub projects: Vec<DVFProjectConfig>,
     #[serde(skip_serializing)]
     pub active_chain_id: Option<u64>,
     #[serde(default, skip_serializing)]
@@ -132,6 +131,8 @@ pub struct DVFConfig {
 pub struct DVFProjectConfig {
     /// Path to the root folder of the source code project (required)
     pub project_path: PathBuf,
+    /// Path to the output DVF file
+    pub output_path: PathBuf,
     /// Project's development environment
     #[serde(default = "default_environment")]
     pub environment: Environment,
@@ -142,7 +143,18 @@ pub struct DVFProjectConfig {
     pub build_cache_path: Option<String>,
     /// Library specifiers in the form Path:Name:Address
     #[serde(default)]
-    pub libraries: Vec<String>,
+    pub libraries: Option<Vec<String>>,
+    /// Address of the contract
+    pub address: Option<Address>,
+    /// Chain ID where the contract is deployed
+    pub chain_id: Option<u64>,
+    /// Name of the contract
+    pub contract_name: String,
+    /// Deployment transaction hash
+    pub deployment_tx: Option<String>,
+    /// Treat this contract as a factory, which changes bytecode verification
+    #[serde(default)]
+    pub factory: bool,
     /// Optional implementation project configuration for proxy contracts
     pub implementation_config: Option<Box<DVFImplementationConfig>>,
 }
@@ -159,6 +171,8 @@ pub struct DVFImplementationConfig {
     pub artifacts_path: String,
     /// Folder containing the implementation contract's build-info files
     pub build_cache_path: Option<String>,
+    /// Name of the implementation contract
+    pub contract_name: String,
 }
 
 fn default_max_blocks() -> u64 {
@@ -252,7 +266,7 @@ impl DVFConfig {
                     secret_key: env::var("SIGNER_SECRET_KEY")?,
                 }),
             }),
-            projects: BTreeMap::new(),
+            projects: Vec::new(),
             active_chain_id: None,
             active_chain: None,
         })
@@ -1150,10 +1164,16 @@ impl DVFConfig {
                 // Create project config
                 let project_config = DVFProjectConfig {
                     project_path,
+                    output_path,
                     environment,
                     artifacts_path,
                     build_cache_path,
                     libraries,
+                    address: None,
+                    chain_id: None,
+                    event_topics: None,
+                    contract_name: None,
+                    factory: false,
                     implementation_config: None, // For now, we'll add implementation config in a future update
                 };
 
@@ -1175,7 +1195,7 @@ impl DVFConfig {
             web3_timeout,
             signer,
             //projects,
-            projects: BTreeMap::new(),
+            projects: Vec::new(),
             active_chain_id: None,
             active_chain: None,
         })
@@ -1425,24 +1445,16 @@ impl DVFConfig {
         )))
     }
 
-    /// Get a project configuration by name
-    pub fn get_project(&self, project_name: &str) -> Option<&DVFProjectConfig> {
-        self.projects.get(project_name)
-    }
-
-    /// Add or update a project configuration
-    pub fn set_project(&mut self, project_name: String, config: DVFProjectConfig) {
-        self.projects.insert(project_name, config);
-    }
-
-    /// Remove a project configuration
-    pub fn remove_project(&mut self, project_name: &str) -> Option<DVFProjectConfig> {
-        self.projects.remove(project_name)
-    }
-
-    /// List all project names
-    pub fn list_projects(&self) -> Vec<&String> {
-        self.projects.keys().collect()
+    /// Get a project configuration by address and chain_id
+    pub fn get_project_config(
+        &self,
+        address: &Address,
+        chain_id: u64,
+    ) -> Option<&DVFProjectConfig> {
+        self.projects.iter().find(|project| {
+            project.address.as_ref() == Some(address)
+                && project.chain_id.as_ref() == Some(&chain_id)
+        })
     }
 }
 

--- a/lib/dvf/discovery.rs
+++ b/lib/dvf/discovery.rs
@@ -34,14 +34,15 @@ pub struct DiscoveryParams<'a> {
     pub libraries: Option<Vec<String>>,
     pub implementation_name: Option<&'a str>,
     pub implementation_project: Option<&'a PathBuf>,
-    pub implementation_env: Environment,
-    pub implementation_artifacts: &'a str,
+    pub implementation_env: Option<&'a Environment>,
+    pub implementation_artifacts: Option<&'a str>,
     pub implementation_build_cache: Option<&'a String>,
     pub zerovalue: bool,
     pub event_topics: Option<Vec<B256>>,
     pub pc: &'a mut u64,
     pub progress_mode: &'a ProgressMode,
     pub use_storage_range: bool,
+    pub tx_hashes: Option<Vec<String>>,
 }
 
 pub struct DiscoveryResult {
@@ -112,7 +113,8 @@ pub fn discover_storage_and_events(
         let imp_path: PathBuf;
         let imp_artifacts_path: PathBuf;
         if let Some(imp_project) = params.implementation_project {
-            imp_artifacts_path = get_project_paths(imp_project, params.implementation_artifacts);
+            imp_artifacts_path =
+                get_project_paths(imp_project, params.implementation_artifacts.unwrap());
             imp_path = imp_project.clone();
         } else if let Some(project_path) = params.project {
             imp_path = project_path.clone();
@@ -126,7 +128,7 @@ pub fn discover_storage_and_events(
         let tmp_project_info = ProjectInfo::new(
             &implementation_name.to_string(),
             &imp_path,
-            params.implementation_env,
+            *params.implementation_env.unwrap(),
             &imp_artifacts_path,
             params.implementation_build_cache,
             params.libraries.clone(),
@@ -153,38 +155,19 @@ pub fn discover_storage_and_events(
         types.extend(tmp_project_info.types.clone());
         imp_project_info = Some(tmp_project_info);
     }
-
-    // Get transaction hashes based on event topics
-    let mut seen_events: Vec<Log> = vec![];
-    let tx_hashes: Vec<String> = if let Some(event_topics) = &params.event_topics {
-        print_progress(
-            "Obtaining past events and transactions.",
-            params.pc,
-            params.progress_mode,
-        );
-        seen_events = web3::get_eth_events(
+    let (tx_hashes, mut seen_events) = if params.tx_hashes.is_none() {
+        // Get transaction hashes based on event topics
+        get_tx_hashes(
             params.config,
             params.address,
             params.start_block_num,
             params.end_block_num,
-            event_topics,
-        )?;
-        seen_events
-            .iter()
-            .filter_map(|e| e.transaction_hash.map(|h| format!("{h:#x}")))
-            .collect()
-    } else {
-        print_progress(
-            "Obtaining past transactions.",
+            params.event_topics.clone(),
             params.pc,
             params.progress_mode,
-        );
-        web3::get_all_txs_for_contract(
-            params.config,
-            params.address,
-            params.start_block_num,
-            params.end_block_num,
         )?
+    } else {
+        (params.tx_hashes.unwrap(), vec![])
     };
 
     print_progress("Getting storage snapshot.", params.pc, params.progress_mode);
@@ -408,6 +391,36 @@ pub fn discover_storage_and_events(
     })
 }
 
+pub fn get_tx_hashes(
+    config: &DVFConfig,
+    address: &Address,
+    start_block_num: u64,
+    end_block_num: u64,
+    event_topics: Option<Vec<B256>>,
+    pc: &mut u64,
+    progress_mode: &ProgressMode,
+) -> Result<(Vec<String>, Vec<Log>), ValidationError> {
+    let mut seen_events: Vec<Log> = vec![];
+    let tx_hashes: Vec<String> = if let Some(event_topics) = &event_topics {
+        print_progress("Obtaining past events and transactions.", pc, progress_mode);
+        seen_events = web3::get_eth_events(
+            config,
+            address,
+            start_block_num,
+            end_block_num,
+            event_topics,
+        )?;
+        seen_events
+            .iter()
+            .filter_map(|e| e.transaction_hash.map(|h| format!("{h:#x}")))
+            .collect()
+    } else {
+        print_progress("Obtaining past transactions.", pc, progress_mode);
+        web3::get_all_txs_for_contract(config, address, start_block_num, end_block_num)?
+    };
+    Ok((tx_hashes, seen_events))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn create_discovery_params_for_init<'a>(
     config: &'a DVFConfig,
@@ -416,7 +429,7 @@ pub fn create_discovery_params_for_init<'a>(
     init_block_num: u64,
     project: &'a PathBuf,
     artifacts: &'a str,
-    env: Environment,
+    env: &'a Environment,
     build_cache: Option<&'a String>,
     libraries: Option<Vec<String>>,
     zerovalue: bool,
@@ -433,21 +446,25 @@ pub fn create_discovery_params_for_init<'a>(
         end_block_num: init_block_num,
         project: Some(project),
         artifacts,
-        env,
+        env: *env,
         build_cache,
         libraries,
         implementation_name: sub_m
             .get_one::<String>("implementation")
             .map(|s| s.as_str()),
         implementation_project: sub_m.get_one::<PathBuf>("implementationproject"),
-        implementation_env: env,
-        implementation_artifacts: sub_m.get_one::<String>("implementationartifacts").unwrap(),
+        implementation_env: Some(env),
+        implementation_artifacts: sub_m
+            .get_one::<String>("implementationartifacts")
+            .as_ref()
+            .map(|s| s.as_str()),
         implementation_build_cache: sub_m.get_one::<String>("implementationbuildcache"),
         zerovalue,
         event_topics,
         pc,
         progress_mode,
         use_storage_range: true,
+        tx_hashes: None,
     }
 }
 
@@ -481,13 +498,17 @@ pub fn create_discovery_params_for_update<'a>(
             .get_one::<String>("implementation")
             .map(|s| s.as_str()),
         implementation_project: sub_m.get_one::<PathBuf>("implementationproject"),
-        implementation_env: *sub_m.get_one::<Environment>("implementationenv").unwrap(),
-        implementation_artifacts: sub_m.get_one::<String>("implementationartifacts").unwrap(),
+        implementation_env: sub_m.get_one::<Environment>("implementationenv"),
+        implementation_artifacts: sub_m
+            .get_one::<String>("implementationartifacts")
+            .as_ref()
+            .map(|s| s.as_str()),
         implementation_build_cache: sub_m.get_one::<String>("implementationbuildcache"),
         zerovalue,
         event_topics: None, // Update mode doesn't filter by event topics
         pc,
         progress_mode,
         use_storage_range: false, // cannot use storage range here as we are only trying to get a subset of the state
+        tx_hashes: None,
     }
 }

--- a/lib/dvf/parse.rs
+++ b/lib/dvf/parse.rs
@@ -403,6 +403,44 @@ impl CompleteDVF {
         Ok(filled)
     }
 
+    pub fn new(
+        contract_name: &str,
+        address: &Address,
+        chain_id: u64,
+    ) -> Result<Self, ValidationError> {
+        let dumped = CompleteDVF {
+            version: CURRENT_VERSION,
+            id: None,
+            contract_name: contract_name.to_string(),
+            address: *address,
+            chain_id,
+            codehash: String::new(),
+            deployment_tx: String::new(),
+            deployment_block_num: 0,
+            init_block_num: 0,
+            insecure: Some(false),
+            immutables: vec![],
+            constructor_args: vec![],
+            critical_storage_variables: vec![],
+            critical_events: vec![],
+            expiry_in_epoch_seconds: None,
+            references: None,
+            unvalidated_metadata: Some(Unvalidated {
+                author_name: Some(String::from("Author")),
+                description: Some(String::from("System Description")),
+                hardfork: Some(vec![String::from("paris"), String::from("shanghai")]),
+                audit_report: Some(String::from("https://example.org/report.pdf")),
+                source_url: Some(String::from("https://github.com/source/code")),
+                security_contact: Some(String::from("security@example.org")),
+                implementation_name: None,
+                implementation_address: None, // currently no source for this
+            }),
+            signature: None,
+        };
+        dumped.check_version()?;
+        Ok(dumped)
+    }
+
     pub fn from_cli(matches: &ArgMatches) -> Result<Self, ValidationError> {
         let immutables: Vec<DVFImmutableEntry> = vec![];
         let critical_storage_variables: Vec<DVFStorageEntry> = vec![];

--- a/lib/utils/progress.rs
+++ b/lib/utils/progress.rs
@@ -7,6 +7,9 @@ pub enum ProgressMode {
     BytecodeCheck,
     GenerateBuildCache,
     ListEvents,
+    InspectTx,
+    InspectTxSub,
+    InspectTxSubNoconf,
 }
 
 pub fn print_progress(s: &str, i: &mut u64, pm: &ProgressMode) {
@@ -20,6 +23,9 @@ pub fn print_progress(s: &str, i: &mut u64, pm: &ProgressMode) {
         ProgressMode::BytecodeCheck => 3,
         ProgressMode::GenerateBuildCache => 1,
         ProgressMode::ListEvents => 1,
+        ProgressMode::InspectTx => 10,
+        ProgressMode::InspectTxSub => 10,
+        ProgressMode::InspectTxSubNoconf => 4,
     };
     println!("{} {}", style(format!("[{i:2}/{total:2}]")).bold().dim(), s);
     *i += 1;

--- a/lib/web3.rs
+++ b/lib/web3.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use std::str::FromStr;
 use std::time::Duration;
 
+use alloy_rpc_types_trace::parity::CallType;
 use colored::Colorize;
 use indicatif::ProgressBar;
 use reqwest::blocking::get;
@@ -2314,4 +2315,85 @@ pub fn get_eth_transaction_block_number(
     let receipt = u64::from_str_radix(block_number_hex.trim_start_matches("0x"), 16)
         .map_err(|_| ValidationError::from("Failed to parse block number from hex"))?;
     Ok(receipt)
+}
+
+pub fn get_all_addresses(
+    config: &DVFConfig,
+    tx_id: &str,
+) -> Result<(Vec<Address>, Vec<Address>), ValidationError> {
+    let mut call_addresses: Vec<Address> = vec![];
+    let mut create_addresses: Vec<Address> = vec![];
+
+    // Try to get transaction trace using get_tx_trace first
+    match get_tx_trace(config, tx_id) {
+        Ok(traces) => {
+            debug!("Using parity trace for {}", tx_id);
+            for trace in &traces {
+                match &trace.action {
+                    // we only care for contracts whose state can change during the call, so no staticcall, delegatecall etc.
+                    Action::Call(call) if call.call_type == CallType::Call => {
+                        call_addresses.push(call.to);
+                    }
+                    Action::Create(_create) => {
+                        // For create actions, we need to check the result
+                        if let Some(TraceOutput::Create(create_res)) = &trace.result {
+                            create_addresses.push(create_res.address);
+                        }
+                    }
+                    _ => {
+                        // do nothing
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            debug!("Parity trace failed with {:?}, trying geth debug trace.", e);
+            // Fallback to geth debug call trace
+            let call_frame = get_eth_debug_call_trace(config, tx_id)?;
+            extract_all_addresses_from_call_frame(
+                &call_frame,
+                &mut call_addresses,
+                &mut create_addresses,
+            )?;
+        }
+    }
+
+    // Remove duplicates while preserving order
+    call_addresses.sort();
+    call_addresses.dedup();
+    create_addresses.sort();
+    create_addresses.dedup();
+
+    debug!("All addresses for {} are: {:?}", tx_id, call_addresses);
+    debug!(
+        "All create addresses for {} are: {:?}",
+        tx_id, create_addresses
+    );
+    Ok((call_addresses, create_addresses))
+}
+
+// Extract all addresses from a CallFrame (geth debug trace)u
+fn extract_all_addresses_from_call_frame(
+    call_frame: &CallFrame,
+    call_addresses: &mut Vec<Address>,
+    create_addresses: &mut Vec<Address>,
+) -> Result<(), ValidationError> {
+    // Add the 'to' address if it exists and the call didn't fail
+    // we only care for contracts whose state can change during the call, so no staticcall, delegatecall etc.
+    if call_frame.error.is_none() {
+        if let Some(addr) = call_frame.to {
+            if call_frame.typ == "CALL" {
+                call_addresses.push(addr);
+            } else if call_frame.typ == "CREATE" {
+                create_addresses.push(addr);
+            }
+        }
+    }
+
+    // Recursively process all sub-calls
+    for call in &call_frame.calls {
+        extract_all_addresses_from_call_frame(call, call_addresses, create_addresses)?;
+    }
+
+    Ok(())
 }

--- a/src/dvf.rs
+++ b/src/dvf.rs
@@ -13,10 +13,11 @@ use dvf_libs::bytecode_verification::verify_bytecode;
 use dvf_libs::dvf::config::{replace_tilde, DVFConfig};
 use dvf_libs::dvf::discovery::{
     create_discovery_params_for_init, create_discovery_params_for_update,
-    discover_storage_and_events, DiscoveryResult,
+    discover_storage_and_events, DiscoveryParams, DiscoveryResult,
 };
 use dvf_libs::dvf::parse::{self, DVFStorageEntry, ValidationError, CURRENT_VERSION_STRING};
 use dvf_libs::dvf::registry::{self, Registry};
+// use dvf_libs::state::forge_inspect::{StateVariable, TypeDescription};
 use dvf_libs::utils::pretty::PrettyPrinter;
 use dvf_libs::utils::progress::{print_progress, ProgressMode};
 use dvf_libs::utils::read_write_file::get_project_paths;
@@ -734,6 +735,22 @@ fn main() {
                 )
                 .arg(arg!(--buildcache <PATH>).help("Folder containing build-info files")),
         )
+        .subcommand(
+            Command::new("inspect-tx")
+                .about("Inspect a transaction and load project configuration from config file")
+                .arg(
+                    arg!(--txhash <TXHASH>)
+                        .help("Transaction hash to inspect (32 byte hex)")
+                        .required(true)
+                        .value_parser(is_valid_32_byte_hex),
+                )
+                .arg(
+                    arg!(--chainid <CHAINID>)
+                        .help("Chain ID where the transaction is located")
+                        .value_parser(value_parser!(u64))
+                        .default_value("1"),
+                ),
+        )
         .get_matches();
 
     match matches.get_count("verbose") {
@@ -981,7 +998,7 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
                 init_block_num,
                 project,
                 artifacts,
-                env,
+                &env,
                 build_cache,
                 libraries.clone(),
                 zerovalue,
@@ -994,77 +1011,21 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
             dumped.critical_storage_variables = critical_storage_variables;
             dumped.critical_events = critical_events;
 
-            let mut pc = 1;
-            println!();
-            println!("DVF Initialization complete. Please follow these steps:");
-
-            if project_info.compiler_version < FIRST_STORAGE_LAYOUT {
-                println!(
-                    "{}. Warning. You are using an old compiler without storage layout. There will be no storage decoding.", pc
-                );
-                pc += 1;
-            } else if proxy_warning && sub_m.get_one::<String>("implementation").is_none() {
-                println!(
-                    "{}. Warning. Some storage slots could not be decoded. This might happen because this is a proxy contract. In that case, use --implementation to decode more.", pc
-                );
-                pc += 1;
-            }
-
-            println!("{pc}. Validate that the results in the table below are as expected.");
-            pc += 1;
-            verify_bytecode::print_generation_summary(
-                &project.to_string_lossy().to_string(),
-                &dumped.contract_name,
-                &dumped.address,
-                compare_status,
+            finalize_init_and_print(
+                project.to_string_lossy().to_string(),
+                &mut dumped,
+                output_path,
                 &project_info,
+                proxy_warning,
+                sub_m,
+                &storage_var_table,
+                &all_events,
+                &event_table,
+                init_block_num,
+                compare_status,
                 &rpc_code,
                 &pretty_printer,
-            );
-            if !dumped.critical_storage_variables.is_empty() {
-                println!(
-                    "{}. Select critical storage variables by deleting the others from {}.",
-                    pc,
-                    output_path.display()
-                );
-                pc += 1;
-
-                if storage_var_table.is_empty() {
-                    println!("    No values were decoded, this could be because it is a proxy contract or because of an old compiler version.");
-                } else {
-                    println!("    Below you see decoded values for non-zero storage variables:");
-                    storage_var_table.printstd();
-                }
-            }
-
-            if !all_events.is_empty() {
-                println!(
-                    "{}. Select critical events by deleting the others from {}",
-                    pc,
-                    output_path.display()
-                );
-                pc += 1;
-
-                if event_table.is_empty() {
-                    println!("   No events occurred up until block {}.", init_block_num);
-                } else {
-                    println!("   Event occurrences up to block {}:", init_block_num);
-                    event_table.printstd();
-                }
-            }
-
-            println!(
-                "{}. Decide whether you want to signal that the contract is insecure, if so set the insecure flag to true.", pc
-            );
-            pc += 1;
-
-            println!(
-                "{}. Decide if this validation should have an expiry date. Also you can fill in additional, unvalidated metadata.", pc
-            );
-
-            dumped.generate_id()?;
-            dumped.write_to_file(output_path)?;
-            println!("Wrote DVF to {}!", output_path.display());
+            )?;
             exit(0);
         }
         Some(("id", sub_m)) => {
@@ -1641,8 +1602,465 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
             println!("Bytecode check succeeded!");
             exit(0);
         }
+        Some(("inspect-tx", sub_m)) => {
+            let tx_hash = sub_m.get_one::<String>("txhash").unwrap();
+            let chain_id = *sub_m.get_one::<u64>("chainid").unwrap();
+
+            config.set_chain_id(chain_id)?;
+
+            let mut pc = 1_u64;
+            let progress_mode = ProgressMode::InspectTx;
+
+            print_progress("Inspecting transaction.", &mut pc, &progress_mode);
+            println!("Chain ID: {}", chain_id);
+
+            let (call_addresses, create_addresses) = web3::get_all_addresses(&config, tx_hash)?;
+            let block_num = web3::get_eth_transaction_block_number(&config, tx_hash)?;
+            println!("The transaction called the following contracts:");
+            for address in &call_addresses {
+                println!("- {}", address);
+            }
+            println!("The transaction created the following contracts:");
+            for address in &create_addresses {
+                println!("- {}", address);
+            }
+
+            let registry = registry::Registry::from_config(&config)?;
+            let pretty_printer = PrettyPrinter::new(&config, Some(&registry));
+
+            print_progress("Checking called contracts.", &mut pc, &progress_mode);
+            for address in &call_addresses {
+                println!("Checking contract: {}", address);
+                inspect_called_contract(
+                    &config,
+                    chain_id,
+                    address,
+                    block_num,
+                    tx_hash,
+                    sub_m,
+                    &pretty_printer,
+                    &mut pc,
+                    &progress_mode,
+                )?;
+            }
+
+            print_progress("Checking created contracts.", &mut pc, &progress_mode);
+            for address in &create_addresses {
+                println!("Checking contract: {}", address);
+                inspect_called_contract(
+                    &config,
+                    chain_id,
+                    address,
+                    block_num,
+                    tx_hash,
+                    sub_m,
+                    &pretty_printer,
+                    &mut pc,
+                    &progress_mode,
+                )?;
+            }
+
+            /*
+            // Iterate over all projects
+            for (i, project_config) in config.projects.iter().enumerate() {
+                println!("\n--- Project {}: {} ---", i + 1, project_config.contract_name);
+
+                println!("Project Path: {}", project_config.project_path.display());
+                println!("Environment: {:?}", project_config.environment);
+                println!("Artifacts Path: {}", project_config.artifacts_path);
+
+                if let Some(ref build_cache) = project_config.build_cache_path {
+                    println!("Build Cache: {}", build_cache);
+                }
+
+                if project_config.libraries.is_some() {
+                    println!("Libraries: {}", project_config.libraries.as_ref().unwrap().join(", "));
+                }
+
+                if let Some(ref address) = project_config.address {
+                    println!("Contract Address: {}", address);
+                }
+
+                if let Some(chain_id) = project_config.chain_id {
+                    println!("Chain ID: {}", chain_id);
+                }
+
+                if project_config.factory {
+                    println!("Factory Contract: Yes");
+                }
+
+                if let Some(ref event_topics) = project_config.event_topics {
+                    println!("Event Topics: {:?}", event_topics);
+                }
+
+                // Check if implementation config exists
+                if let Some(ref impl_config) = project_config.implementation_config {
+                    println!("Implementation Project:");
+                    println!("  Path: {}", impl_config.project_path.display());
+                    println!("  Environment: {:?}", impl_config.environment);
+                    println!("  Artifacts Path: {}", impl_config.artifacts_path);
+                    if let Some(ref build_cache) = impl_config.build_cache_path {
+                        println!("  Build Cache: {}", build_cache);
+                    }
+                    println!("  Contract Name: {}", impl_config.contract_name);
+                }
+            }
+
+            println!("\nNote: This command shows all available project configurations.");
+            println!("To perform detailed transaction analysis, consider using the 'init' command");
+            println!("with a specific project's contract address and name.");
+
+            */
+
+            exit(0);
+        }
         _ => Err(ValidationError::Error(
             "Please specify a command.".to_string(),
         )),
     }
+}
+
+fn wrap_by_length(s: &str, max_len: usize, delimiter: &str) -> String {
+    if max_len == 0 {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + s.len() / max_len);
+    let mut count = 0;
+    for ch in s.chars() {
+        if count == max_len {
+            out.push_str(delimiter);
+            count = 0;
+        }
+        out.push(ch);
+        count += 1;
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finalize_init_and_print(
+    project_dir: String,
+    dumped: &mut parse::CompleteDVF,
+    output_path: &Path,
+    project_info: &ProjectInfo,
+    proxy_warning: bool,
+    sub_m: &ArgMatches,
+    storage_var_table: &Table,
+    all_events: &[alloy::json_abi::Event],
+    event_table: &Table,
+    init_block_num: u64,
+    compare_status: CompareBytecode,
+    rpc_code: &String,
+    pretty_printer: &PrettyPrinter,
+) -> Result<(), ValidationError> {
+    let mut pc = 1;
+    println!();
+    println!("DVF Initialization complete. Please follow these steps:");
+
+    if project_info.compiler_version < FIRST_STORAGE_LAYOUT {
+        println!(
+            "{}. Warning. You are using an old compiler without storage layout. There will be no storage decoding.", pc
+        );
+        pc += 1;
+    } else if proxy_warning && sub_m.get_one::<String>("implementation").is_none() {
+        println!(
+            "{}. Warning. Some storage slots could not be decoded. This might happen because this is a proxy contract. In that case, use --implementation to decode more.", pc
+        );
+        pc += 1;
+    }
+
+    println!("{pc}. Validate that the results in the table below are as expected.");
+    pc += 1;
+    verify_bytecode::print_generation_summary(
+        &project_dir,
+        &dumped.contract_name,
+        &dumped.address,
+        compare_status,
+        project_info,
+        rpc_code,
+        pretty_printer,
+    );
+    if !dumped.critical_storage_variables.is_empty() {
+        println!(
+            "{}. Select critical storage variables by deleting the others from {}.",
+            pc,
+            output_path.display()
+        );
+        pc += 1;
+
+        if storage_var_table.is_empty() {
+            println!("    No values were decoded, this could be because it is a proxy contract or because of an old compiler version.");
+        } else {
+            println!("    Below you see decoded values for non-zero storage variables:");
+            storage_var_table.printstd();
+        }
+    }
+
+    if !all_events.is_empty() {
+        println!(
+            "{}. Select critical events by deleting the others from {}",
+            pc,
+            output_path.display()
+        );
+        pc += 1;
+
+        if event_table.is_empty() {
+            println!("   No events occurred up until block {}.", init_block_num);
+        } else {
+            println!("   Event occurrences up to block {}:", init_block_num);
+            event_table.printstd();
+        }
+    }
+
+    println!(
+        "{}. Decide whether you want to signal that the contract is insecure, if so set the insecure flag to true.", pc
+    );
+    pc += 1;
+
+    println!(
+        "{}. Decide if this validation should have an expiry date. Also you can fill in additional, unvalidated metadata.", pc
+    );
+
+    dumped.generate_id()?;
+    dumped.write_to_file(output_path)?;
+    println!("Wrote DVF to {}!", output_path.display());
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inspect_called_contract(
+    config: &DVFConfig,
+    chain_id: u64,
+    address: &Address,
+    block_num: u64,
+    tx_hash: &String,
+    sub_m: &ArgMatches,
+    pretty_printer: &PrettyPrinter,
+    pc: &mut u64,
+    progress_mode: &ProgressMode,
+) -> Result<(), ValidationError> {
+    let project_config = config.get_project_config(address, chain_id);
+    if let Some(project_config) = project_config {
+        println!(
+            "Project configuration found for contract: {} ({})",
+            address, project_config.contract_name
+        );
+        let mut pc_sub = 1_u64;
+        let progress_mode_sub = ProgressMode::InspectTxSub;
+        let mut dumped =
+            parse::CompleteDVF::new(project_config.contract_name.as_str(), address, chain_id)?;
+
+        let (deployment_block_num, deployment_tx) =
+            if let Some(depl_tx) = project_config.deployment_tx.as_ref() {
+                let block_num = web3::get_eth_transaction_block_number(config, depl_tx.as_str())?;
+                (block_num, depl_tx.clone())
+            } else {
+                web3::get_deployment(config, &dumped.address)?
+            };
+        dumped.deployment_block_num = deployment_block_num;
+        dumped.deployment_tx = deployment_tx;
+        dumped.init_block_num = block_num;
+
+        print_progress("Getting code hash.", &mut pc_sub, &progress_mode_sub);
+        let rpc_code_hash = web3::get_eth_codehash(config, &dumped.address, deployment_block_num)?;
+        dumped.codehash = rpc_code_hash;
+
+        print_progress(
+            "Fetching on-chain bytecode.",
+            &mut pc_sub,
+            &progress_mode_sub,
+        );
+        let rpc_code = web3::get_eth_code(config, &dumped.address, deployment_block_num)?;
+
+        print_progress("Fetching init code.", &mut pc_sub, &progress_mode_sub);
+        let init_code = web3::get_init_code(config, &dumped.deployment_tx, &dumped.address)?;
+
+        debug!("Fetching forge output");
+        let compile_output = match project_config.build_cache_path {
+            None => "Compiling local code.",
+            Some(_) => "Loading build cache.",
+        };
+        print_progress(compile_output, pc, progress_mode);
+        let mut project_info = ProjectInfo::new(
+            &project_config.contract_name,
+            Path::new(&project_config.project_path),
+            project_config.environment,
+            Path::new(&project_config.artifacts_path),
+            project_config.build_cache_path.as_ref(),
+            project_config.libraries.clone(),
+        )?;
+
+        print_progress("Comparing bytecode.", &mut pc_sub, &progress_mode_sub);
+        let compare_status =
+            CompareBytecode::compare(&mut project_info, project_config.factory, &rpc_code);
+
+        if !compare_status.matched {
+            return Err(ValidationError::from(
+                "Generation Failed. Bytecode mismatch.",
+            ));
+        }
+
+        print_progress("Comparing initcode.", &mut pc_sub, &progress_mode_sub);
+        let compare_init =
+            CompareInitCode::compare(&mut project_info, &init_code, project_config.factory);
+        if !compare_init.matched {
+            return Err(ValidationError::from(
+                "Initcode mismatch. Consider setting the factory flag in the project configuration if this is a factory contract.",
+            ));
+        }
+        // immutable values are set in CompareBytecode::compare so this has to be after the call
+        dumped.copy_immutables(&project_info, pretty_printer);
+
+        debug!("Copying parsed constructor arguments to dvf file");
+        dumped.copy_constructor_args(&project_info, pretty_printer);
+
+        let DiscoveryResult {
+            critical_storage_variables,
+            critical_events,
+            storage_var_table,
+            event_table,
+            all_events,
+            proxy_warning,
+        } = discover_storage_and_events(DiscoveryParams {
+            config,
+            contract_name: &project_config.contract_name,
+            address,
+            start_block_num: block_num,
+            end_block_num: block_num,
+            project: Some(PathBuf::from(&project_config.project_path)).as_ref(),
+            artifacts: &project_config.artifacts_path,
+            env: project_config.environment,
+            build_cache: project_config.build_cache_path.as_ref(),
+            libraries: project_config.libraries.clone(),
+            implementation_name: project_config
+                .implementation_config
+                .as_ref()
+                .map(|impl_config| impl_config.contract_name.as_str()),
+            implementation_project: project_config
+                .implementation_config
+                .as_ref()
+                .map(|impl_config| PathBuf::from(&impl_config.project_path))
+                .as_ref(),
+            implementation_env: project_config
+                .implementation_config
+                .as_ref()
+                .map(|impl_config| impl_config.environment)
+                .as_ref(),
+            implementation_artifacts: project_config
+                .implementation_config
+                .as_ref()
+                .map(|impl_config| impl_config.artifacts_path.as_str()),
+            implementation_build_cache: project_config
+                .implementation_config
+                .as_ref()
+                .and_then(|impl_config| impl_config.build_cache_path.as_ref()),
+            zerovalue: false,
+            event_topics: None,
+            pc: &mut pc_sub,
+            progress_mode: &progress_mode_sub,
+            use_storage_range: false,
+            tx_hashes: Some(vec![tx_hash.clone()]),
+        })?;
+
+        dumped.critical_storage_variables = critical_storage_variables;
+        dumped.critical_events = critical_events;
+
+        finalize_init_and_print(
+            project_config.project_path.to_string_lossy().to_string(),
+            &mut dumped,
+            &project_config.output_path,
+            &project_info,
+            proxy_warning,
+            sub_m,
+            &storage_var_table,
+            &all_events,
+            &event_table,
+            block_num,
+            compare_status,
+            &rpc_code,
+            pretty_printer,
+        )?;
+    } else {
+        println!(
+            "No project configuration found for contract {}. Skipping bytecode check and storage decoding.",
+            address
+        );
+
+        let mut pc_sub = 1_u64;
+        let progress_mode_sub = ProgressMode::InspectTxSubNoconf;
+
+        let tx_hashes = vec![tx_hash.clone()];
+
+        print_progress("Getting storage snapshot.", &mut pc_sub, &progress_mode_sub);
+        let snapshot =
+            web3::StorageSnapshot::from_api(config, address, block_num, &tx_hashes, false)?;
+
+        print_progress("Parsing storage snapshot.", &mut pc_sub, &progress_mode_sub);
+        let mut storage_var_table = Table::new();
+        storage_var_table.set_titles(row!["Slot", "Offset", "Value"]);
+        let unused = snapshot.get_unused_nonzero_storage_slots();
+        for unused_part in unused {
+            let slot_hex = format!("0x{:x}", unused_part.slot);
+            let value_hex = format!("0x{}", hex::encode(&unused_part.value));
+            storage_var_table.add_row(row![
+                slot_hex,
+                unused_part.offset,
+                wrap_by_length(&value_hex, 66, "\n"),
+            ]);
+        }
+
+        print_progress("Obtaining past events.", &mut pc_sub, &progress_mode_sub);
+        let seen_events = web3::get_eth_events(config, address, block_num, block_num, &vec![])?;
+
+        let mut event_table = Table::new();
+        let mut critical_events: Vec<parse::DVFEventEntry> = vec![];
+        let all_topics_0: HashSet<B256> =
+            seen_events.iter().map(|e| *e.topic0().unwrap()).collect();
+        for unused_topic in all_topics_0 {
+            let mut table_head = false;
+            // Collect Occurrences
+            let mut occurrences: Vec<parse::DVFEventOccurrence> = vec![];
+            for seen_event in &seen_events {
+                let log_inner = &seen_event.inner;
+                if seen_event.topic0() == Some(&unused_topic) {
+                    // Add Event Name to table
+                    if !table_head {
+                        event_table.add_row(row![unused_topic]);
+                        table_head = true;
+                    }
+                    // Add Event Occurrence to table
+                    let msg = format!("{}", seen_event.inner.data.data);
+                    event_table.add_row(row![format!("- {}", wrap_by_length(&msg, 64, "\n  "))]);
+                    let occurrence = parse::DVFEventOccurrence {
+                        topics: log_inner.data.topics().to_vec(),
+                        data: log_inner.data.data.clone(),
+                    };
+                    occurrences.push(occurrence);
+                }
+            }
+            let event_entry = parse::DVFEventEntry {
+                sig: String::from("Unknown Signature"),
+                topic0: unused_topic,
+                occurrences,
+            };
+            critical_events.push(event_entry);
+        }
+
+        if !storage_var_table.is_empty() {
+            println!("Storage changes of {} in transaction {}:", address, tx_hash);
+            storage_var_table.printstd();
+            if !event_table.is_empty() {
+                println!();
+            }
+        }
+        if !event_table.is_empty() {
+            println!(
+                "Event occurrences of {} in transaction {}:",
+                address, tx_hash
+            );
+            event_table.printstd();
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Adds the "inspect-tx" command that allows to see all touched contracts and their changed storage slots as well as emitted events in a given transaction.

For each contract, a project configuration can be added to the config file that will be used to compile the contract, compare the bytecode and decode storage slots.

If no such configuration is present, the command simply outputs the undecoded storage slots and events.