### PR TITLE
FEAT: Add new known addresses file argument to init

### DIFF
--- a/lib/dvf/registry.rs
+++ b/lib/dvf/registry.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use alloy::primitives::Address;
+use serde_json;
 use tracing::debug;
 
 use crate::dvf::config::DVFConfig;
@@ -15,15 +16,24 @@ use crate::utils::pretty::{AddressType, ResolvedAddress};
 pub struct Registry {
     dvf_storage: PathBuf,
     trusted_signers: Vec<Address>,
+    known_addresses: HashMap<u64, HashMap<Address, ResolvedAddress>>,
 }
 
 impl Registry {
     pub fn from_config(config: &DVFConfig) -> Result<Self, ValidationError> {
+        Self::from_config_with_known(config, None)
+    }
+
+    pub fn from_config_with_known(
+        config: &DVFConfig,
+        known_addresses: Option<HashMap<u64, HashMap<Address, ResolvedAddress>>>,
+    ) -> Result<Self, ValidationError> {
         let dvf_storage = config.dvf_storage.clone();
 
         Ok(Registry {
             dvf_storage,
             trusted_signers: config.trusted_signers.clone(),
+            known_addresses: known_addresses.unwrap_or_default(),
         })
     }
 
@@ -31,8 +41,26 @@ impl Registry {
         self.trusted_signers.contains(address)
     }
 
+    pub fn load_known_addresses_from_file(
+        path: &Path,
+    ) -> Result<HashMap<u64, HashMap<Address, ResolvedAddress>>, ValidationError> {
+        let f = fs::File::open(path)?;
+        serde_json::from_reader::<_, HashMap<u64, HashMap<Address, ResolvedAddress>>>(f).map_err(
+            |e| {
+                ValidationError::Error(format!(
+                    "Could not parse known addresses file {}: {}",
+                    path.display(),
+                    e
+                ))
+            },
+        )
+    }
+
     pub fn collect_name_resolution(&self, chain_id: u64) -> HashMap<Address, ResolvedAddress> {
         let mut res: HashMap<Address, ResolvedAddress> = HashMap::new();
+        if let Some(extra) = self.known_addresses.get(&chain_id) {
+            res.extend(extra.clone());
+        }
         self.collect_names_inner(&self.dvf_storage, &mut res, chain_id);
         res
     }
@@ -174,4 +202,43 @@ fn search_for_id(dir: &Path, id: &String) -> Result<Vec<PathBuf>, ValidationErro
         }
     }
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Registry;
+    use crate::dvf::config::DVFConfig;
+    use alloy::primitives::Address;
+    use std::fs;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_known_addresses_and_collect() {
+        let dir = tempdir().unwrap();
+        let known_path = dir.path().join("known.json");
+        let json = r#"
+        {
+            "1": {
+                "0x1111111111111111111111111111111111111111": {
+                    "name": "TestContract",
+                    "address_type": "Contract"
+                }
+            }
+        }
+        "#;
+        fs::write(&known_path, json).unwrap();
+
+        let known = Registry::load_known_addresses_from_file(&known_path).unwrap();
+
+        let mut config = DVFConfig::default();
+        config.dvf_storage = dir.path().to_path_buf();
+
+        let registry = Registry::from_config_with_known(&config, Some(known)).unwrap();
+
+        let resolved = registry.collect_name_resolution(1);
+        let addr = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        assert_eq!(resolved.get(&addr).unwrap().name, "TestContract");
+        assert!(registry.collect_name_resolution(137).is_empty());
+    }
 }

--- a/lib/utils/pretty.rs
+++ b/lib/utils/pretty.rs
@@ -17,7 +17,7 @@ use crate::dvf::config::DVFConfig;
 use crate::dvf::registry::Registry;
 use crate::state::contract_state::ContractState;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum AddressType {
     Token,
     Contract,
@@ -26,7 +26,7 @@ pub enum AddressType {
     Eoa,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ResolvedAddress {
     pub address_type: AddressType,
     pub name: String,

--- a/src/dvf.rs
+++ b/src/dvf.rs
@@ -485,6 +485,11 @@ fn main() {
                     arg!(<OUTPUT>)
                         .help("Path of the generated DVF file")
                         .required(true),
+                )
+                .arg(
+                    arg!(--knownaddressesfile <PATH>)
+                        .help("Optional JSON file with known addresses to include in name resolution")
+                        .value_parser(is_valid_path),
                 ),
         )
         .subcommand(
@@ -865,7 +870,12 @@ fn process(matches: ArgMatches) -> Result<(), ValidationError> {
             let mut dumped = parse::CompleteDVF::from_cli(sub_m)?;
             config.set_chain_id(dumped.chain_id)?;
 
-            let registry = registry::Registry::from_config(&config)?;
+            let known_addresses = sub_m
+                .get_one::<PathBuf>("knownaddressesfile")
+                .map(|path| registry::Registry::load_known_addresses_from_file(path))
+                .transpose()?;
+
+            let registry = registry::Registry::from_config_with_known(&config, known_addresses)?;
             let pretty_printer = PrettyPrinter::new(&config, Some(&registry));
 
             // Parse optional initblock or take deployment_block_num + 1


### PR DESCRIPTION
Add a new argument to the init command to load known addresses from a JSON file with the following structure (1 is the chainID): 

```json
{
  "1": {
    "0xf949982b91c8c61e952b3ba942cbbfaef5386684": {
        "name": "CollateralRegistry",
        "address_type": "Contract"
    }
  }   
}
```

Such known addresses are then stored in the registry and are used to decode addresses and make it easier to verify deployment.